### PR TITLE
Ignore any exceptions thrown for undreadable child directories

### DIFF
--- a/src/FileManipulator.php
+++ b/src/FileManipulator.php
@@ -34,7 +34,8 @@ final class FileManipulator
         $fileIterator = new \RegexIterator(
             new \RecursiveIteratorIterator(
                 new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
-                \RecursiveIteratorIterator::SELF_FIRST
+                \RecursiveIteratorIterator::SELF_FIRST,
+                \RecursiveIteratorIterator::CATCH_GET_CHILD
             ),
             \sprintf('/%s$/', self::TARGET)
         );


### PR DESCRIPTION
Hey,

I tried out this tool earlier and it fell over because of some folders it couldn't read, namely some icloud photo folders. It seems we can just pass a flag to the iterator to catch and ignore any exceptions thrown. 

I tried to add a test but the tests don't seem to run properly on my system:

```
c run-test
You made a reference to a non-existent script @prepare-for-test
> vendor/bin/phpunit --coverage-text --colors=never
PHPUnit 7.5.16 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.3.8
Configuration: /Users/aydin/projects/killposer/phpunit.xml.dist
Error:         No code coverage driver is available

F

Time: 25 ms, Memory: 4.00 MB

There was 1 failure:

1) Killposer\Tests\FileManipulatorTest::testValidSeekNoThreshold
Failed asserting that actual size 0 matches expected size 3.

/Users/aydin/projects/killposer/tests/FileManipulatorTest.php:31

FAILURES!
Tests: 1, Assertions: 1, Failures: 1.
Script vendor/bin/phpunit --coverage-text --colors=never handling the phpunit event returned with error code 1
Script @phpunit was called via run-test
```